### PR TITLE
fix: Enable Docker workflow trigger when new release published

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 name: docker-build
 
 on:
+  workflow_dispatch:
+  release:
+    types: [published]
   push:
     tags: [ 'v*' ]
 
@@ -28,6 +31,7 @@ jobs:
         tags: |
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
+          type=ref,event=branch
           type=raw,value=latest
 
     - name: Build and push


### PR DESCRIPTION
## Description

Docker workflow with branch tagging support and enable trigger when new release published
